### PR TITLE
Not working f home on first home creation

### DIFF
--- a/src/DaPigGuy/PiggyFactions/factions/Faction.php
+++ b/src/DaPigGuy/PiggyFactions/factions/Faction.php
@@ -257,12 +257,14 @@ class Faction
     public function setHome(Position $home): void
     {
         $this->home = $home;
+        $this->homeWorld = $home->getWorld();
         $this->update();
     }
 
     public function unsetHome(): void
     {
         $this->home = null;
+        $this->homeWorld = null;
         $this->update();
     }
 


### PR DESCRIPTION

<!-- Failure to complete the required fields will result in the issue being closed. -->
Please make sure your pull request complies with these guidelines:
- * [X] Use same formatting
- * [ ] Changes must have been tested on PMMP.
- * [X] Unless it is a minor code modification, you must use an IDE.
- * [X] Have a detailed title.

#### **What does the PR change?**
The homeWorld variable is checked when the player does /f home to teleport to his faction home. The thing is that it's always null until the server reboots. So if the faction is new and the home is new the player cannot teleport to it. I don't really understand why homeWorld exists but maybe it's usefull so here is a fix.
There's no real issue opened to it.
<!-- 
Does your Pull Request:
- resolve a bug? If so, link the issue with the PR and add explain what caused the issue.
- enhance the plugin? If so, explain what this adds, including why it should be added.
-->

#### **Testing Environment**
<!-- PHP and OS version required, pmmp build link required. -->
N/A

#### **Extra Information**
N/A
