### PR TITLE
/f help crash with negative int 

### DIFF
--- a/src/DaPigGuy/PiggyFactions/commands/subcommands/HelpSubCommand.php
+++ b/src/DaPigGuy/PiggyFactions/commands/subcommands/HelpSubCommand.php
@@ -33,7 +33,7 @@ class HelpSubCommand extends FactionSubCommand
 
         $commandsPerPage = $sender instanceof Player ? self::COMMANDS_PER_PAGE : count($subcommands);
         $maxPages = (int)ceil(count($subcommands) / $commandsPerPage);
-        $page = ((int)$args["page"]) ?? 1;
+        $page = (int)($args["page"] ?? 1);
         $page = min($page, $maxPages);
         if ($page < 1) $page = 1;
         $pageCommands = array_slice($subcommands, $commandsPerPage * ($page - 1), $commandsPerPage);

--- a/src/DaPigGuy/PiggyFactions/commands/subcommands/HelpSubCommand.php
+++ b/src/DaPigGuy/PiggyFactions/commands/subcommands/HelpSubCommand.php
@@ -33,7 +33,7 @@ class HelpSubCommand extends FactionSubCommand
 
         $commandsPerPage = $sender instanceof Player ? self::COMMANDS_PER_PAGE : count($subcommands);
         $maxPages = (int)ceil(count($subcommands) / $commandsPerPage);
-        $page = $args["page"] ?? 1;
+        $page = ((int)$args["page"]) ?? 1;
         $page = min($page, $maxPages);
         if ($page < 1) $page = 1;
         $pageCommands = array_slice($subcommands, $commandsPerPage * ($page - 1), $commandsPerPage);

--- a/src/DaPigGuy/PiggyFactions/commands/subcommands/HelpSubCommand.php
+++ b/src/DaPigGuy/PiggyFactions/commands/subcommands/HelpSubCommand.php
@@ -35,6 +35,7 @@ class HelpSubCommand extends FactionSubCommand
         $maxPages = (int)ceil(count($subcommands) / $commandsPerPage);
         $page = $args["page"] ?? 1;
         $page = min($page, $maxPages);
+        if ($page < 1) $page = 1;
         $pageCommands = array_slice($subcommands, $commandsPerPage * ($page - 1), $commandsPerPage);
 
         $language = $sender instanceof Player ? $this->plugin->getLanguageManager()->getPlayerLanguage($sender) : $this->plugin->getLanguageManager()->getDefaultLanguage();


### PR DESCRIPTION
<!-- Failure to complete the required fields will result in the issue being closed. -->
Please make sure your pull request complies with these guidelines:
- * [X] Use same formatting
- * [ ] Changes must have been tested on PMMP.
- * [X] Unless it is a minor code modification, you must use an IDE.
- * [X] Have a detailed title.

#### **What does the PR change?**
<!-- 
Does your Pull Request:
- resolve a bug? If so, link the issue with the PR and add explain what caused the issue.
- enhance the plugin? If so, explain what this adds, including why it should be added.
-->
No issue related to the PR but a crash issue when a player is sending a command like `/f help -999999999999999999990248723227848934734798473279839872783788793738379384`.
This is too large for an int so it becomes

