### PR TITLE
Fix '/f top money'

### DIFF
--- a/src/DaPigGuy/PiggyFactions/commands/subcommands/TopSubCommand.php
+++ b/src/DaPigGuy/PiggyFactions/commands/subcommands/TopSubCommand.php
@@ -32,14 +32,13 @@ class TopSubCommand extends FactionSubCommand
                 return (int)($b->getPower() - $a->getPower());
             }
         ];
-        $type = $args["type"] ?? "power";
-        if (!isset($types[$type])) return;
-
         if ($this->plugin->isFactionBankEnabled()) {
             $types["money"] = function (Faction $a, Faction $b): int {
                 return (int)($b->getMoney() - $a->getMoney());
             };
         }
+        $type = $args["type"] ?? "power";
+        if (!isset($types[$type])) return;
 
         $factions = array_filter($this->plugin->getFactionsManager()->getFactions(), function (Faction $faction): bool {
             return !$faction->getFlag(Flag::SAFEZONE) && !$faction->getFlag(Flag::WARZONE);


### PR DESCRIPTION
Please make sure your pull request complies with these guidelines:
- * [x] Use same formatting
- * [x] Changes must have been tested on PMMP.
- * [x] Unless it is a minor code modification, you must use an IDE.
- * [x] Have a detailed title.

#### **What does the PR change?**
Fixes '/f top money' since it did not output anything before.
Simply adds the "money" option into the $types array before checking if the player argument is set in the $types array.

#### **Testing Environment**
- PHP: 8.2
- PMMP: [5.14.1](https://github.com/pmmp/PocketMine-MP/releases/tag/5.14.1)
- OS: Windows 10
